### PR TITLE
Bump actions/checkout and actions/cache to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             cabalopts: '-f-doctests --write-ghc-environment-files=always'
             testopts: '--test-option=--hide-successes'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # needed by memory
     - name: Install numa
@@ -81,7 +81,7 @@ jobs:
 
     - name: Cache cabal global package db
       id:   cabal-global
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cabal
@@ -104,11 +104,11 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Cache stack global package db
       id:   stack-global-package-db
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           C:\Users\runneradmin\AppData\Roaming\stack\
@@ -134,7 +134,7 @@ jobs:
             cabal: '3.10'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install ghc/cabal
       run: |
@@ -143,7 +143,7 @@ jobs:
 
     - name: Cache cabal global package db
       id:   cabal-global
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cabal
@@ -171,7 +171,7 @@ jobs:
           - ghc: '9.6'
             cabal: '3.10'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install icu
       run: sudo apt-get install libicu-dev
@@ -183,7 +183,7 @@ jobs:
 
     - name: Cache cabal global package db
       id:   cabal-global
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cabal


### PR DESCRIPTION
The checkout and cache actions in the GitHub actions workflow file are using v2 actions which use Node12, which is deprecated.

This leads to the many warnings in the `Actions` tab of Github.