### PR TITLE
Support GHC 9.10.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
             prefix: ''
             cabalopts: '-f-doctests --write-ghc-environment-files=always'
             testopts: '--test-option=--hide-successes'
+          - ghc: '9.10'
+            cabal: '3.10'
+            prefix: ''
+            cabalopts: '-f-doctests --write-ghc-environment-files=always'
+            testopts: '--test-option=--hide-successes'
     steps:
     - uses: actions/checkout@v2
 

--- a/unicode-collation.cabal
+++ b/unicode-collation.cabal
@@ -35,6 +35,7 @@ tested-with:         GHC == 8.4.4
                      GHC == 9.4.2
                      GHC == 9.6.3
                      GHC == 9.8.1
+                     GHC == 9.10.1
 
 source-repository head
   type:                git
@@ -50,7 +51,7 @@ flag executable
   Default:             False
 
 common common-options
-  build-depends:       base >= 4.11 && < 4.20
+  build-depends:       base >= 4.11 && < 4.21
 
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
Bump the upper bound on base to include 4.21, and add GHC 9.10.1 to the version tested in CI.