### PR TITLE
Support GHC 9.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
             prefix: ''
             cabalopts: '-f-doctests --write-ghc-environment-files=always'
             testopts: '--test-option=--hide-successes'
+          - ghc: '9.12'
+            cabal: '3.14'
+            prefix: ''
+            cabalopts: '-f-doctests --write-ghc-environment-files=always'
+            testopts: '--test-option=--hide-successes'
     steps:
     - uses: actions/checkout@v4
 

--- a/unicode-collation.cabal
+++ b/unicode-collation.cabal
@@ -51,7 +51,7 @@ flag executable
   Default:             False
 
 common common-options
-  build-depends:       base >= 4.11 && < 4.21
+  build-depends:       base >= 4.11 && < 4.22
 
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
I'm not a Haskell programmer, so I would hope this is sufficient to make
this work. I have also opened composewell/unicode-transforms#100 to
upgrade that to build for GHC 9.12.

This is in support of getting pandoc to build with GHC 9.12 for
MacPorts.
